### PR TITLE
Use urlsafe_base64 for random key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In the view you can use url helper for defining link:
 In the model you'll need to add the parameter :masqueradable to the existing comma separated values in the devise method:
 
     devise :invitable, :confirmable, :database_authenticatable, :registerable, :masqueradable
-         
+
 Add into your application_controller.rb:
 
     before_filter :masquerade_user!
@@ -76,7 +76,7 @@ helpers:
 
     Devise.masquerade_param = 'masquerade'
     Devise.masquerade_expires_in = 10.seconds
-    Devise.masquerade_key_size = 16 # size of the generate by SecureRandom.base64
+    Devise.masquerade_key_size = 16 # size of the generate by SecureRandom.urlsafe_base64
 
 ## Demo project
 

--- a/lib/devise_masquerade/model.rb
+++ b/lib/devise_masquerade/model.rb
@@ -12,7 +12,7 @@ module Devise
 
       module InstanceMethods
         def masquerade!
-          @masquerade_key = SecureRandom.base64(Devise.masquerade_key_size)
+          @masquerade_key = SecureRandom.urlsafe_base64(Devise.masquerade_key_size)
 
           Rails.cache.write("#{self.class.name.pluralize.downcase}:#{@masquerade_key}:masquerade", id, :expires_in => Devise.masquerade_expires_in)
         end

--- a/spec/controllers/devise/masquerades_controller_spec.rb
+++ b/spec/controllers/devise/masquerades_controller_spec.rb
@@ -11,7 +11,7 @@ describe Devise::MasqueradesController do
         let(:mask) { create(:user) }
 
         before do
-          SecureRandom.should_receive(:base64).and_return("secure_key")
+          SecureRandom.should_receive(:urlsafe_base64).and_return("secure_key")
 
           get :show, :id => mask.to_param
         end
@@ -34,7 +34,7 @@ describe Devise::MasqueradesController do
         let(:mask) { create(:user) }
 
         before do
-          SecureRandom.should_receive(:base64).and_return("secure_key")
+          SecureRandom.should_receive(:urlsafe_base64).and_return("secure_key")
           get :show, :id => mask.to_param
         end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,13 +5,13 @@ describe User do
 
   describe '#masquerade!' do
     it 'should cache special key on masquerade' do
-      SecureRandom.should_receive(:base64).with(16).and_return("secure_key")
+      SecureRandom.should_receive(:urlsafe_base64).with(16).and_return("secure_key")
       user.masquerade!
     end
   end
 
   describe '#remove_masquerade_key' do
-    before { SecureRandom.stub(:base64).and_return("secure_key") }
+    before { SecureRandom.stub(:urlsafe_base64).and_return("secure_key") }
 
     let(:key) { 'users:secure_key:masquerade' }
 


### PR DESCRIPTION
This fixes issue with random keys containing `+` characters, which get translated to spaces in the Rails controller.
