### PR TITLE
Fix `RuntimeError: Could not find a valid mapping for nil`

### DIFF
--- a/app/controllers/devise/masquerades_controller.rb
+++ b/app/controllers/devise/masquerades_controller.rb
@@ -17,7 +17,13 @@ class Devise::MasqueradesController < DeviseController
   end
 
   def back
-    owner_user = resource_class.to_adapter.find_first(:id => session[session_key])
+    user_id = session[session_key]
+
+    owner_user = if user_id.present?
+                   resource_class.to_adapter.find_first(:id => user_id)
+                 else
+                   send(:"current_#{resouce_name}")
+                 end
 
     sign_in(owner_user, :bypass => Devise.masquerade_bypass_warden_callback)
 


### PR DESCRIPTION
Steps to reproduce the bug:
1. Open two pages under masqueraded user 
2. Turn off (back) masquerading on the first page
3. Try to turn off masquerading on the second page

After that you will see `RuntimeError: Could not find a valid mapping for nil` because user id from session is nil.
