### PR TITLE
Fix deprecation warnings in Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In the model you'll need to add the parameter :masqueradable to the existing com
 
 Add into your application_controller.rb:
 
-    before_filter :masquerade_user!
+    before_action :masquerade_user!
 
 Instead of user you can use your resource name admin, student or another names.
 

--- a/app/controllers/devise/masquerades_controller.rb
+++ b/app/controllers/devise/masquerades_controller.rb
@@ -1,8 +1,8 @@
 class Devise::MasqueradesController < DeviseController
-  prepend_before_filter :authenticate_scope!
+  prepend_before_action :authenticate_scope!
 
-  before_filter :save_masquerade_owner_session, :only => :show
-  after_filter :cleanup_masquerade_owner_session, :only => :back
+  before_action :save_masquerade_owner_session, :only => :show
+  after_action :cleanup_masquerade_owner_session, :only => :back
 
   def show
     self.resource = resource_class.to_adapter.find_first(:id => params[:id])

--- a/spec/dummy/app/controllers/admin/dashboard_controller.rb
+++ b/spec/dummy/app/controllers/admin/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class Admin::DashboardController < ApplicationController
-  before_filter :authenticate_admin_user!
-  before_filter :masquerade_admin_user!
+  before_action :authenticate_admin_user!
+  before_action :masquerade_admin_user!
 
   def index
     @users = Admin::User.where("admin_users.id != ?", current_admin_user.id).all

--- a/spec/dummy/app/controllers/dashboard_controller.rb
+++ b/spec/dummy/app/controllers/dashboard_controller.rb
@@ -1,6 +1,6 @@
 class DashboardController < ApplicationController
-  before_filter :authenticate_user!
-  before_filter :masquerade_user!
+  before_action :authenticate_user!
+  before_action :masquerade_user!
 
   def index
     @users = User.where("users.id != ?", current_user.id).all


### PR DESCRIPTION
This fixes the following deprecation warnings:

```
DEPRECATION WARNING: prepend_before_filter is deprecated and will be removed in Rails 5.1. Use prepend_before_action instead. (called from <top (required)> at /srv/divi/app/controllers/admin/masquerades_controller.rb:1)
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead. (called from <top (required)> at /srv/divi/app/controllers/admin/masquerades_controller.rb:1)
DEPRECATION WARNING: after_filter is deprecated and will be removed in Rails 5.1. Use after_action instead. (called from <top (required)> at /srv/divi/app/controllers/admin/masquerades_controller.rb:1)
```