### PR TITLE
Maintain original swap id through multiple swaps

### DIFF
--- a/app/controllers/devise/masquerades_controller.rb
+++ b/app/controllers/devise/masquerades_controller.rb
@@ -80,7 +80,7 @@ class Devise::MasqueradesController < DeviseController
   end
 
   def save_masquerade_owner_session
-    session[session_key] = send("current_#{resource_name}").id
+    session[session_key] = send("current_#{resource_name}").id unless session.key? session_key
   end
 
   def cleanup_masquerade_owner_session


### PR DESCRIPTION
This allows an admin to swap to another account (who may also have permission to swap) and continue swapping as such.  The admin will not have to end their masquerade, but just keep changing until they'd like to go back to their original form.