### PR TITLE
Allow masquerade to route back instead of new path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ in `routes.rb`:
     Devise.masquerade_expires_in = 10.seconds
     Devise.masquerade_key_size = 16 # size of the generate by SecureRandom.urlsafe_base64
     Devise.masquerade_bypass_warden_callback = false
+    Devise.masquerade_routes_back = false # if true, route back to the page the user was on via redirect_back
 
 ## Demo project
 

--- a/app/controllers/devise/masquerades_controller.rb
+++ b/app/controllers/devise/masquerades_controller.rb
@@ -35,8 +35,10 @@ class Devise::MasqueradesController < DeviseController
       sign_in(self.resource)
     end
 
-    if Devise.masquerade_routes_back
+    if Devise.masquerade_routes_back && Rails::VERSION::MAJOR == 5
       redirect_back(fallback_location: "#{after_masquerade_param_for(self.resource)}?#{after_masquerade_param_for(resource)}")
+    elsif Devise.masquerade_routes_back && request.env['HTTP_REFERER'].present?
+      redirect_to :back
     else
       redirect_to("#{after_masquerade_path_for(self.resource)}?#{after_masquerade_param_for(resource)}")
     end
@@ -62,8 +64,11 @@ class Devise::MasqueradesController < DeviseController
     end
     request.env["devise.skip_trackable"] = nil
 
-    if Devise.masquerade_routes_back
+    if Devise.masquerade_routes_back && Rails::VERSION::MAJOR == 5
+      # If using the masquerade_routes_back and Rails 5
       redirect_back(fallback_location: after_back_masquerade_path_for(owner_user))
+    elsif Devise.masquerade_routes_back && request.env['HTTP_REFERER'].present?
+      redirect_to :back
     else
       redirect_to after_back_masquerade_path_for(owner_user)
     end

--- a/app/controllers/devise/masquerades_controller.rb
+++ b/app/controllers/devise/masquerades_controller.rb
@@ -35,7 +35,11 @@ class Devise::MasqueradesController < DeviseController
       sign_in(self.resource)
     end
 
-    redirect_to("#{after_masquerade_path_for(self.resource)}?#{after_masquerade_param_for(resource)}")
+    if Devise.masquerade_routes_back
+      redirect_back(fallback_location: "#{after_masquerade_param_for(self.resource)}?#{after_masquerade_param_for(resource)}")
+    else
+      redirect_to("#{after_masquerade_path_for(self.resource)}?#{after_masquerade_param_for(resource)}")
+    end
   end
 
   def back
@@ -58,7 +62,11 @@ class Devise::MasqueradesController < DeviseController
     end
     request.env["devise.skip_trackable"] = nil
 
-    redirect_to after_back_masquerade_path_for(owner_user)
+    if Devise.masquerade_routes_back
+      redirect_back(fallback_location: after_back_masquerade_path_for(owner_user))
+    else
+      redirect_to after_back_masquerade_path_for(owner_user)
+    end
   end
 
   private

--- a/lib/devise_masquerade.rb
+++ b/lib/devise_masquerade.rb
@@ -24,6 +24,9 @@ module Devise
   mattr_accessor :masquerade_bypass_warden_callback
   @@masquerade_bypass_warden_callback = false
 
+  mattr_accessor :masquerade_routes_back
+  @@masquerade_routes_back = false
+
   @@helpers << DeviseMasquerade::Controllers::Helpers
 end
 

--- a/spec/controllers/devise/masquerades_controller_spec.rb
+++ b/spec/controllers/devise/masquerades_controller_spec.rb
@@ -26,6 +26,45 @@ describe Devise::MasqueradesController, type: :controller do
           it { expect(current_user.reload).to eq(@user) }
           it { expect(session.keys).not_to include('devise_masquerade_user') }
         end
+
+        # Configure masquerade_routes_back setting
+        describe 'config#masquerade_routes_back' do
+          before { Devise.setup {|c| c.masquerade_routes_back = true } }
+
+          context 'show' do
+            before { expect(SecureRandom).to receive(:urlsafe_base64) { "secure_key" } }
+
+            context '< Rails 5 version' do
+              before do
+                @request.env['HTTP_REFERER'] = 'previous_location'
+                get :show, id: mask.to_param
+              end # before
+
+              it { should redirect_to('previous_location') }
+            end # context
+
+            context '< Rails 5, fallback if http_referer not present' do
+              before { get :show, id: mask.to_param }
+
+              it { should redirect_to("/?masquerade=secure_key") }
+            end # context
+          end # context
+
+          context '< Rails 5, and back' do
+            before { get :back }
+
+            it { should redirect_to(masquerade_page) }
+          end # context
+
+          context '< Rails 5, and back fallback if http_referer not present' do
+            before do
+              @request.env['HTTP_REFERER'] = 'previous_location'
+              get :back
+            end
+
+            it { should redirect_to('previous_location') }
+          end # context
+        end # describe
       end
     end
 


### PR DESCRIPTION
This allows gem to be configured to use the (rails 5) redirect_back method to maintain the user on the same page as when they invoked masquerade, which allows for a quicker navigation of a site for an admin (e.g. masquerade can be invoked through an element such as a modal from any page within a site to choose a user and see what they see on the given page).