### PR TITLE
Handle paths that include query strings

### DIFF
--- a/app/controllers/devise/masquerades_controller.rb
+++ b/app/controllers/devise/masquerades_controller.rb
@@ -31,11 +31,11 @@ class Devise::MasqueradesController < DeviseController
     masquerade_sign_in(self.resource)
 
     if Devise.masquerade_routes_back && Rails::VERSION::MAJOR == 5
-      redirect_back(fallback_location: "#{after_masquerade_param_for(self.resource)}?#{after_masquerade_param_for(resource)}")
+      redirect_back(fallback_location: after_masquerade_full_path_for(resource))
     elsif Devise.masquerade_routes_back && request.env['HTTP_REFERER'].present?
       redirect_to :back
     else
-      redirect_to("#{after_masquerade_path_for(self.resource)}?#{after_masquerade_param_for(resource)}")
+      redirect_to(after_masquerade_full_path_for(resource))
     end
   end
 
@@ -103,6 +103,14 @@ class Devise::MasqueradesController < DeviseController
 
   def after_masquerade_path_for(resource)
     "/"
+  end
+
+  def after_masquerade_full_path_for(resource)
+    if after_masquerade_path_for(resource) =~ /\?/
+      "#{after_masquerade_path_for(resource)}&#{after_masquerade_param_for(resource)}"
+    else
+      "#{after_masquerade_path_for(resource)}?#{after_masquerade_param_for(resource)}"
+    end
   end
 
   def after_masquerade_param_for(resource)

--- a/spec/controllers/devise/masquerades_controller_spec.rb
+++ b/spec/controllers/devise/masquerades_controller_spec.rb
@@ -44,9 +44,13 @@ describe Devise::MasqueradesController, type: :controller do
             end # context
 
             context '< Rails 5, fallback if http_referer not present' do
+              before do
+                allow_any_instance_of(described_class).to receive(:after_masquerade_path_for).and_return("/dashboard?color=red")
+              end
+
               before { get :show, id: mask.to_param }
 
-              it { should redirect_to("/?masquerade=secure_key") }
+              it { should redirect_to("/dashboard?color=red&masquerade=secure_key") }
             end # context
           end # context
 


### PR DESCRIPTION
Currently if one overrides `after_masquerade_path_for` and include a query string in the path, the masquerade key is appended with a `?` mark when really it should be a `&`.  This pull request updates the code to check for existing query strings when generating the full path.