### PR TITLE
Pass through additional parameters to path helpers

### DIFF
--- a/lib/devise_masquerade/controllers/url_helpers.rb
+++ b/lib/devise_masquerade/controllers/url_helpers.rb
@@ -1,14 +1,14 @@
 module DeviseMasquerade
   module Controllers
     module UrlHelpers
-      def masquerade_path(resource)
+      def masquerade_path(resource, *args)
         scope = Devise::Mapping.find_scope!(resource)
-        send("#{scope}_masquerade_path", resource)
+        send("#{scope}_masquerade_path", resource, *args)
       end
 
-      def back_masquerade_path(resource)
+      def back_masquerade_path(resource, *args)
         scope = Devise::Mapping.find_scope!(resource)
-        send("back_#{scope}_masquerade_index_path")
+        send("back_#{scope}_masquerade_index_path", *args)
       end
     end
   end


### PR DESCRIPTION
@oivoodoo Currently the URL helpers don't allow passing through additional parameters to the path helpers. This patch allows:

```ruby
masquerade_path(user, foo: 'bar') # => "/users/masquerade/20?foo=bar"
```