### PR TITLE
Added missing global namespace operator

### DIFF
--- a/lib/devise_masquerade/controllers/helpers.rb
+++ b/lib/devise_masquerade/controllers/helpers.rb
@@ -43,7 +43,7 @@ module DeviseMasquerade
 
           def #{name}_masquerade_owner
             return nil unless send(:#{name}_masquerade?)
-            GlobalID::Locator.locate_signed(Rails.cache.read(:"devise_masquerade_#{name}"), for: 'masquerade')
+            GlobalID::Locator.locate_signed(::Rails.cache.read(:"devise_masquerade_#{name}"), for: 'masquerade')
           end
 
           private


### PR DESCRIPTION
Avoid `ActionView::Template::Error (undefined method `cache' for DeviseMasquerade::Rails:Module):` when trying to use `user_masquerade_owner`.