### PR TITLE
Ensure the GlobalID can be properly located for the masquerade_owner

### DIFF
--- a/lib/devise_masquerade/controllers/helpers.rb
+++ b/lib/devise_masquerade/controllers/helpers.rb
@@ -50,7 +50,8 @@ module DeviseMasquerade
             return unless send(:#{name}_masquerade?)
 
             key = "devise_masquerade_#{name}_" + current_#{name}.to_param
-            GlobalID::Locator.locate_signed(::Rails.cache.read(key.to_sym, for: 'masquerade'))
+            sgid = ::Rails.cache.read(key.to_sym, for: 'masquerade')
+            GlobalID::Locator.locate_signed(sgid, for: 'masquerade')
           end
 
           private


### PR DESCRIPTION
When determining the original model that the masquerading model was
signed in as, pass the purpose to the GlobalID library's "locate_signed"
method in order to properly locate the record. Failing to pass the
purpose to that method seemed to result in the record not being found.