### PR TITLE
CI: Drop unused sudo: false Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: ruby
 rvm:
   - 2.6.0
   - 2.7.3
-gemfile:
-  - Gemfile
 script: time ./script/travis.sh
-sudo: false
 addons:
   apt:
     packages:


### PR DESCRIPTION

This PR removes the no-longer-used Travis setting `sudo: false`. See [more at the Travis blog](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

Also, drop the already-default Gemfile setting.