### PR TITLE
Fix Devise 5 compatibility and add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["3.3", "3.4"]
+        devise: ["4", "5"]
+
+    name: Ruby ${{ matrix.ruby }} / Devise ${{ matrix.devise }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+        env:
+          DEVISE_VERSION: ${{ matrix.devise }}
+
+      - name: Set up database
+        run: |
+          cd spec/dummy && bundle exec rake db:schema:load
+        env:
+          RAILS_ENV: test
+          DEVISE_VERSION: ${{ matrix.devise }}
+
+      - name: Run RSpec
+        run: bundle exec rspec
+        env:
+          RAILS_ENV: test
+          DEVISE_VERSION: ${{ matrix.devise }}
+
+      - name: Run Cucumber
+        run: bundle exec cucumber
+        env:
+          RAILS_ENV: test
+          DEVISE_VERSION: ${{ matrix.devise }}

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,12 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in devise_masquerade.gemspec
 gemspec
 
+if ENV["DEVISE_VERSION"] == "5"
+  gem "devise", "~> 5.0"
+elsif ENV["DEVISE_VERSION"] == "4"
+  gem "devise", "~> 4.9"
+end
+
 group :test do
   gem 'activerecord', '>= 8.0.3'
 

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -7,15 +7,12 @@ Dummy::Application.configure do
   # and recreated between test runs.  Don't rely on the data there!
   config.cache_classes = true
 
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
   # Show full error reports and disable caching
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment
   config.action_controller.allow_forgery_protection    = false

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_100000) do
+ActiveRecord::Schema[7.2].define(version: 2019_10_22_100000) do
 
   create_table "admin_users", force: :cascade do |t|
     t.string "email", default: "", null: false

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -10,7 +10,7 @@ module Authentication
 
   def admin_logged_in
     @admin_user ||= create(:admin_user)
-    sign_in(:admin, @admin_user)
+    sign_in(@admin_user, scope: :admin)
   end
 
   def current_admin_user


### PR DESCRIPTION
## Summary

This PR fixes test compatibility with Devise 5 and adds a GitHub Actions CI workflow to test against both Devise 4 and Devise 5.

### Changes

**Fix deprecated `sign_in` call in test helper (`spec/support/authentication.rb`)**

Devise 5 removed the two-argument `sign_in(scope, resource)` form. The keyword argument form `sign_in(resource, scope: :scope_name)` works with both Devise 4 and Devise 5:

```ruby
# Before (Devise 4 only)
sign_in(:admin, @admin_user)

# After (Devise 4 and 5)
sign_in(@admin_user, scope: :admin)
```

**Add GitHub Actions CI workflow (`.github/workflows/ci.yml`)**

- Runs on push to master/main and on pull requests
- Tests against a matrix of Ruby 3.3/3.4 and Devise 4/5
- Runs both `bundle exec rspec` and `bundle exec cucumber`
- Uses `DEVISE_VERSION` env var to control Devise version pinning

**Update Gemfile for version matrix support**

Added a conditional block that respects the `DEVISE_VERSION` environment variable to pin `devise ~> 4.9` or `devise ~> 5.0`. When unset, the gemspec's `devise >= 4.7.0` constraint applies as before.

**Fix dummy app for modern Rails compatibility**

- `spec/dummy/db/schema.rb`: Use `ActiveRecord::Schema[7.2].define(...)` instead of the deprecated `ActiveRecord::Schema.define(...)` format (required by Rails 7.2+)
- `spec/dummy/config/environments/test.rb`: Remove `config.whiny_nils` (removed in Rails 4) and change `show_exceptions = false` to `show_exceptions = :none` (required since Rails 7.1)